### PR TITLE
Serialise nested collections in column major order

### DIFF
--- a/src/main/kotlin/dev/bright/vb6serializer/CollectionLikeSerializer.kt
+++ b/src/main/kotlin/dev/bright/vb6serializer/CollectionLikeSerializer.kt
@@ -1,0 +1,21 @@
+package dev.bright.vb6serializer
+
+import kotlinx.serialization.InternalSerializationApi
+import kotlinx.serialization.SerializationStrategy
+import kotlinx.serialization.internal.AbstractCollectionSerializer
+
+@OptIn(InternalSerializationApi::class)
+internal object CollectionLikeSerializer {
+    private val elementSerializer =
+        javaClass.classLoader.loadClass("kotlinx.serialization.internal.CollectionLikeSerializer")
+            .getDeclaredField("elementSerializer").apply { isAccessible = true }
+
+    fun <T> elementSerializer(serializer: AbstractCollectionSerializer<T, *, *>): SerializationStrategy<*> =
+        elementSerializer.get(serializer) as SerializationStrategy<*>
+}
+
+@OptIn(InternalSerializationApi::class)
+internal fun <T> AbstractCollectionSerializer<T, *, *>.elementSerializer(
+): SerializationStrategy<*> {
+    return CollectionLikeSerializer.elementSerializer(this)
+}

--- a/src/main/kotlin/dev/bright/vb6serializer/Input.kt
+++ b/src/main/kotlin/dev/bright/vb6serializer/Input.kt
@@ -35,6 +35,10 @@ internal class Input private constructor(
     // TODO: that's not accurate
     val isComplete: Boolean get() = stream.available() <= 0
 
+    fun readAllBytes(): ByteArray {
+        return stream.readAllBytes()
+    }
+
     companion object {
         fun create(stream: InputStream) = Input(ByteCountingInputStream(stream))
     }

--- a/src/main/kotlin/dev/bright/vb6serializer/TransposeInPlace.kt
+++ b/src/main/kotlin/dev/bright/vb6serializer/TransposeInPlace.kt
@@ -11,7 +11,7 @@ internal fun transposeInPlace(serialized: ByteArray, rows: Int, cols: Int, eleme
             serialized[jByteSizeIndex + x] = temp
         }
     }
-    // https://stackoverflow.com/questions/9227747/in-place-transposition-of-a-matrix
+    // https://stackoverflow.com/a/9320349
     val lastIndex = rows * cols - 1
     val visited = BooleanArray(rows * cols)
 

--- a/src/main/kotlin/dev/bright/vb6serializer/TransposeInPlace.kt
+++ b/src/main/kotlin/dev/bright/vb6serializer/TransposeInPlace.kt
@@ -1,0 +1,31 @@
+package dev.bright.vb6serializer
+
+internal fun transposeInPlace(serialized: ByteArray, rows: Int, cols: Int, elementByteSize: Int) {
+    fun swapElement(i: Int, j: Int) {
+        val iByteSizeIndex = i * elementByteSize
+        val jByteSizeIndex = j * elementByteSize
+
+        for (x in 0 until elementByteSize) {
+            val temp = serialized[iByteSizeIndex + x]
+            serialized[iByteSizeIndex + x] = serialized[jByteSizeIndex + x]
+            serialized[jByteSizeIndex + x] = temp
+        }
+    }
+    // https://stackoverflow.com/questions/9227747/in-place-transposition-of-a-matrix
+    val lastIndex = rows * cols - 1
+    val visited = BooleanArray(rows * cols)
+
+    for (ix in 1 until lastIndex) {// 0 and lastIndex shouldn't move
+        if (visited[ix]) {
+            continue
+        }
+
+        var cycleStartIndex = ix
+        do {
+            cycleStartIndex = if (cycleStartIndex == lastIndex) lastIndex else (rows * cycleStartIndex) % lastIndex
+            // Swap arr[a] and arr[cycleIndex]
+            swapElement(cycleStartIndex, ix)
+            visited[cycleStartIndex] = true
+        } while (cycleStartIndex != ix)
+    }
+}

--- a/src/main/kotlin/dev/bright/vb6serializer/VB6Binary.kt
+++ b/src/main/kotlin/dev/bright/vb6serializer/VB6Binary.kt
@@ -38,11 +38,20 @@ open class VB6Binary(override val serializersModule: SerializersModule, private 
     }
 
     override fun <T> encodeToByteArray(serializer: SerializationStrategy<T>, value: T): ByteArray {
-        val outputStream = ByteArrayOutputStream()
-        val dumper = BinaryEncoder(Output.create(outputStream), serializersModule, configuration)
-        dumper.encodeSerializableValue(serializer, value)
-        return outputStream.toByteArray()
+        return serializedBytesOf(serializersModule, configuration, serializer, value)
     }
+}
+
+internal fun <T> serializedBytesOf(
+    serializersModule: SerializersModule,
+    configuration: VB6BinaryConfiguration,
+    serializer: SerializationStrategy<T>,
+    value: T
+): ByteArray {
+    val outputStream = ByteArrayOutputStream()
+    val dumper = BinaryEncoder(Output.create(outputStream), serializersModule, configuration)
+    dumper.encodeSerializableValue(serializer, value)
+    return outputStream.toByteArray()
 }
 
 internal val defaultSerializingCharset = Charset.forName("ISO-8859-8")


### PR DESCRIPTION
This should in principle be compatible with how VB6 handles multidimensional collections.

I don't like how the serialisation part handles that in a serializer and the deserialization part in a decoder. However, that can be refactored without changing the public API. I've only realised that once I started working on the deserialization.

It turns out that transposing a rectangular matrix (i.e. changing the row-major order to column-major order is not a trivial task https://en.wikipedia.org/wiki/In-place_matrix_transposition despite what it seems like from ChatGPT responses :D )