### PR TITLE
Fix VELO-497: Change charset to the one used in old presto

### DIFF
--- a/src/main/kotlin/dev/bright/vb6serializer/VB6Binary.kt
+++ b/src/main/kotlin/dev/bright/vb6serializer/VB6Binary.kt
@@ -59,4 +59,4 @@ internal fun <T> serializedBytesOf(
     return outputStream.toByteArray()
 }
 
-internal val defaultSerializingCharset = Charset.forName("ISO-8859-8")
+internal val defaultSerializingCharset = Charset.forName("Windows-1255")


### PR DESCRIPTION
### Task
<!-- Add links to task and other relevant resources -->
 - [Task Link](https://bright-inventions.atlassian.net/browse/VELO-497)

### Description
<!-- Describe the solution, changes, etc. -->
- There were cases of wrong encoding in one of the restaurants. Changing encoding fixes that issue.

### Screenshots (optional)
Before:
![image](https://github.com/bright/vb6serializer/assets/14942080/ecd141e9-7e15-4810-a965-811c9e60e270)
After:
![image](https://github.com/bright/vb6serializer/assets/14942080/ad48e3b0-70a5-41d7-9ad2-fbf529d98d49)
